### PR TITLE
Set uninitialized scalars and vectors to 0 in OpenGL GLSL

### DIFF
--- a/src/compiler/glsl/glsl_to_nir.cpp
+++ b/src/compiler/glsl/glsl_to_nir.cpp
@@ -727,6 +727,17 @@ nir_visitor::visit(ir_variable *ir)
 
    var->constant_initializer = constant_copy(ir->constant_initializer, var);
 
+   // Set uninitialized scalar and vector values to zero to match behavior
+   // of other OpenGL vendors.  The OpenGL Shading Language specification
+   // states that uninitialized variables have an undefined value but that
+   // doesn't preclude that value always being zero.
+   if (!var->constant_initializer && !var->type->is_array() && !var->type->is_struct() && var->type->matrix_columns == 1) {
+       if (var->data.mode == nir_var_function_temp || var->data.mode == nir_var_shader_temp) {
+           nir_constant *zero = rzalloc(var, nir_constant);
+           var->constant_initializer = zero;
+       }
+   }
+   
    if (var->data.mode == nir_var_function_temp)
       nir_function_impl_add_variable(impl, var);
    else


### PR DESCRIPTION
This matches the behavior of other OpenGL vendors.  The OpenGL Shading Language specification states "Reading a variable before writing (or initializing) it is legal, however the value is undefined".  Undefined doesn't preclude that value always being zero.