### PR TITLE
Ramon/memory fixes

### DIFF
--- a/src/gallium/drivers/zink/zink_context.c
+++ b/src/gallium/drivers/zink/zink_context.c
@@ -127,6 +127,10 @@ zink_context_destroy(struct pipe_context *pctx)
          mesa_loge("ZINK: vkQueueWaitIdle failed (%s)", vk_Result_to_str(result));
    }
 
+   if (ctx->needs_present) {
+      pipe_resource_reference((struct pipe_resource**)&ctx->needs_present, NULL);
+   }
+
    for (unsigned i = 0; i < ARRAY_SIZE(ctx->program_cache); i++) {
       simple_mtx_lock((&ctx->program_lock[i]));
       hash_table_foreach(&ctx->program_cache[i], entry) {

--- a/src/gallium/drivers/zink/zink_screen.c
+++ b/src/gallium/drivers/zink/zink_screen.c
@@ -2018,12 +2018,12 @@ zink_query_memory_info(struct pipe_screen *pscreen, struct pipe_memory_info *inf
             /* VRAM */
             info->total_device_memory += screen->info.mem_props.memoryHeaps[i].size / 1024;
             /* free real estate! */
-            info->avail_device_memory += info->total_device_memory;
+            info->avail_device_memory += screen->info.mem_props.memoryHeaps[i].size / 1024;
          } else {
             /* GART */
             info->total_staging_memory += screen->info.mem_props.memoryHeaps[i].size / 1024;
             /* free real estate! */
-            info->avail_staging_memory += info->total_staging_memory;
+            info->avail_staging_memory += screen->info.mem_props.memoryHeaps[i].size / 1024;
          }
       }
    }


### PR DESCRIPTION
Fix available device memory when memory budget extension is not supported

Fix resources leaking that are needing presenting when a context is destroyed. Desctruction might occur before a pending flush has occurred which will leak the swapchain texture resource if any