### PR TITLE
Add refcount to needs_present

### DIFF
--- a/src/gallium/drivers/zink/zink_screen.c
+++ b/src/gallium/drivers/zink/zink_screen.c
@@ -1553,7 +1553,7 @@ zink_flush_frontbuffer(struct pipe_screen *pscreen,
    if (!zink_kopper_acquired(res->obj->dt, res->obj->dt_idx)) {
       /* swapbuffers to an undefined surface: acquire and present garbage */
       zink_kopper_acquire(ctx, res, UINT64_MAX);
-      ctx->needs_present = res;
+      zink_resource_reference(&ctx->needs_present, res);
       /* set batch usage to submit acquire semaphore */
       zink_batch_resource_usage_set(&ctx->batch, res, true, false);
       /* ensure the resource is set up to present garbage */

--- a/src/gallium/drivers/zink/zink_screen.c
+++ b/src/gallium/drivers/zink/zink_screen.c
@@ -1553,7 +1553,7 @@ zink_flush_frontbuffer(struct pipe_screen *pscreen,
    if (!zink_kopper_acquired(res->obj->dt, res->obj->dt_idx)) {
       /* swapbuffers to an undefined surface: acquire and present garbage */
       zink_kopper_acquire(ctx, res, UINT64_MAX);
-      zink_resource_reference(&ctx->needs_present, res);
+      pipe_resource_reference((struct pipe_resource**)&ctx->needs_present, res);
       /* set batch usage to submit acquire semaphore */
       zink_batch_resource_usage_set(&ctx->batch, res, true, false);
       /* ensure the resource is set up to present garbage */


### PR DESCRIPTION
Fixes a crash when swapchains are swapped in applications. Mesa master has fixes for this, cherry-pick and make it working with our branch. 