### PR TITLE
Clamp blit if swapchain dst resized during acquisition

### DIFF
--- a/src/gallium/drivers/zink/zink_blit.c
+++ b/src/gallium/drivers/zink/zink_blit.c
@@ -286,15 +286,17 @@ zink_blit(struct pipe_context *pctx,
 
    struct zink_resource *src = zink_resource(info->src.resource);
    struct zink_resource *dst = zink_resource(info->dst.resource);
+   struct pipe_blit_info info_copy = *info;
    bool needs_present_readback = false;
    if (zink_is_swapchain(dst)) {
-      VkExtent2D swapchain_size = ctx->swapchain_size;
       if (!zink_kopper_acquire(ctx, dst, UINT64_MAX))
          return;
-      if (swapchain_size.width != ctx->swapchain_size.width ||
-          swapchain_size.height != ctx->swapchain_size.height) {
-         return;
-      }
+      /* Clamp blit if extents exceed swapchain size because of a resize */
+      if (info->dst.box.x + info->dst.box.width > dst->base.b.width0)
+         info_copy.dst.box.width = dst->base.b.width0 - info->dst.box.x;
+      if (info->dst.box.y + info->dst.box.height > dst->base.b.height0)
+         info_copy.dst.box.height = dst->base.b.height0 - info->dst.box.y;
+      info = &info_copy;
    }
 
    if (src_desc == dst_desc ||


### PR DESCRIPTION
Previous fix missed a few cases. This is more general - just clamps the extents to handle any destination image resizing that may have occured. This means the blit still occurs which reduces any flicker (black) which is what happened before sometimes