### PR TITLE
Append old swapchains to the end of the old swapchains list

### DIFF
--- a/src/gallium/drivers/zink/zink_kopper.c
+++ b/src/gallium/drivers/zink/zink_kopper.c
@@ -343,7 +343,7 @@ update_swapchain(struct zink_screen *screen, struct kopper_displaytarget *cdt, u
    prune_old_swapchains(screen, cdt, false);
    struct kopper_swapchain **pswap = &cdt->old_swapchain;
    while (*pswap)
-      *pswap = (*pswap)->next;
+       pswap = &(*pswap)->next;
    *pswap = cdt->swapchain;
    cdt->swapchain = cswap;
 


### PR DESCRIPTION
Previously this code updated the front of the list to point to the latest old swapchain, dangling any other swapchains in that list.  Any old swapchains weren't all destroyed in `prune_old_swapchains()` are then leaked.

Fixed by updating the `pswap` pointer until it reaches the end of the list and then inserting the latest old swapchain there.