### PR TITLE
Do not re-export already imported resources

### DIFF
--- a/src/gallium/drivers/zink/zink_resource.c
+++ b/src/gallium/drivers/zink/zink_resource.c
@@ -1021,8 +1021,11 @@ resource_object_create(struct zink_screen *screen, const struct pipe_resource *t
       emai.sType = VK_STRUCTURE_TYPE_EXPORT_MEMORY_ALLOCATE_INFO;
       emai.handleTypes = export_types;
 
-      emai.pNext = mai.pNext;
-      mai.pNext = &emai;
+      // if imported do not re-export
+      if (!(whandle && whandle->handle)) {
+         emai.pNext = mai.pNext;
+         mai.pNext = &emai;
+      }
       obj->exportable = true;
    }
 


### PR DESCRIPTION
Causes memory to be re-allocated and reading from the other resource basically becomes all zeros. Fixes CATIA ray-traced output not displaying