### PR TITLE
Add a function to destroy the timeline semaphore created when exported buffers/images

### DIFF
--- a/src/gallium/drivers/zink/zink_resource.c
+++ b/src/gallium/drivers/zink/zink_resource.c
@@ -2886,3 +2886,46 @@ zink_cuda_wait_timeline_semaphore(uint64_t semaphore, uint64_t timeline_value,
    return false;
 #endif
 }
+
+/**
+ * Destroy a timeline semaphore created for CUDA interop.
+ */
+#ifdef _WIN32
+__declspec(dllexport)
+#endif
+bool
+zink_cuda_destroy_timeline_semaphore(uint64_t semaphore,
+                                    char* error_msg, size_t error_msg_size)
+{
+   if (!semaphore) {
+      return true;
+   }
+
+#ifdef _WIN32
+   // Get the current Mesa GL context
+   struct gl_context *gl_ctx = _mesa_get_current_context();
+   if (!gl_ctx) {
+      if (error_msg) snprintf(error_msg, error_msg_size, "No current GL context");
+      return false;
+   }
+
+   // Get the Mesa state tracker context
+   struct st_context *st_ctx = (struct st_context*)gl_ctx->st;
+   if (!st_ctx) {
+      if (error_msg) snprintf(error_msg, error_msg_size, "No Mesa state tracker context");
+      return false;
+   }
+
+   struct pipe_context *pipe_ctx = st_ctx->pipe;
+   struct zink_screen *screen = zink_screen(pipe_ctx->screen);
+   VkSemaphore vk_semaphore = (VkSemaphore)(uintptr_t)semaphore;
+
+   VKSCR(QueueWaitIdle)(screen->queue);
+   VKSCR(DestroySemaphore)(screen->dev, vk_semaphore, NULL);
+
+   return true;
+#else
+   if (error_msg) snprintf(error_msg, error_msg_size, "Platform not supported");
+   return false;
+#endif
+}

--- a/src/gallium/drivers/zink/zink_resource.h
+++ b/src/gallium/drivers/zink/zink_resource.h
@@ -108,6 +108,13 @@ bool
 zink_cuda_wait_timeline_semaphore(uint64_t semaphore, uint64_t timeline_value,
                                  char* error_msg, size_t error_msg_size);
 
+#ifdef _WIN32
+__declspec(dllexport)
+#endif
+bool
+zink_cuda_destroy_timeline_semaphore(uint64_t semaphore,
+                                    char* error_msg, size_t error_msg_size);
+
 static inline void
 zink_resource_object_reference(struct zink_screen *screen,
                              struct zink_resource_object **dst,


### PR DESCRIPTION
We should really make Zink track this state