### PR TITLE
wgl: remove per-frame CPU stalls that block frame queue-ahead

### DIFF
--- a/src/gallium/frontends/wgl/stw_context.c
+++ b/src/gallium/frontends/wgl/stw_context.c
@@ -442,13 +442,20 @@ stw_make_current(struct stw_framebuffer *fb, struct stw_framebuffer *fbRead, str
          }
       } else {
          if (old_ctx->shared) {
+            /* JUICE: dropped ST_FLUSH_WAIT here. Upstream Mesa fully drains the
+             * GPU (vkWaitSemaphores, INFINITE) on every switch away from a
+             * shared context to retire shared-resource work before another
+             * context uses it. That CPU stall is a hard CPU<->GPU barrier and,
+             * over Juice's remote vkWaitSemaphores, a synchronous network
+             * round-trip on the render thread's critical path — it defeats
+             * frame queue-ahead. Flush (still needed so the work is submitted)
+             * but do not block; rely on zink's per-batch timeline semaphores to
+             * order cross-context resource access GPU-side. */
             if (old_ctx->current_framebuffer) {
                stw_st_flush(old_ctx->st, old_ctx->current_framebuffer->stfb,
-                            ST_FLUSH_FRONT | ST_FLUSH_WAIT);
+                            ST_FLUSH_FRONT);
             } else {
-               struct pipe_fence_handle *fence = NULL;
-               old_ctx->st->flush(old_ctx->st,
-                                  ST_FLUSH_FRONT | ST_FLUSH_WAIT, &fence,
+               old_ctx->st->flush(old_ctx->st, ST_FLUSH_FRONT, NULL,
                                   NULL, NULL);
             }
          } else {

--- a/src/gallium/frontends/wgl/stw_st.c
+++ b/src/gallium/frontends/wgl/stw_st.c
@@ -399,7 +399,20 @@ stw_st_flush(struct st_context_iface *stctx,
    args.stwfb = stwfb;
    args.flags = flags;
 
-   if (flags & ST_FLUSH_END_OF_FRAME && !stwfb->fb->winsys_framebuffer)
+   /* JUICE: upstream Mesa turns every end-of-frame flush without a winsys
+    * framebuffer into a full CPU drain (ST_FLUSH_WAIT -> vkWaitSemaphores,
+    * INFINITE). That is the primary SwapBuffers throttle and, over Juice's
+    * remote vkWaitSemaphores, a per-frame synchronous network round-trip that
+    * caps queue depth at one frame in flight. It is only needed for the
+    * software-present path (softpipe/llvmpipe gdi_sw_display), which reads the
+    * rendered pixels back on the CPU. Zink presents via kopper:
+    * zink_kopper_present_queue submits a VkPresentInfoKHR that waits on the
+    * render-complete semaphore GPU-side and runs async on the flush queue, so
+    * the CPU drain is redundant. Skip it for zink and let swapchain-image
+    * acquisition (vkAcquireNextImageKHR) provide back-pressure, which is what
+    * enables frame queue-ahead. */
+   if (flags & ST_FLUSH_END_OF_FRAME && !stwfb->fb->winsys_framebuffer &&
+       !stw_dev->zink)
       flags |= ST_FLUSH_WAIT;
 
    if (flags & ST_FLUSH_WAIT)


### PR DESCRIPTION
Two WGL front-end paths force a full CPU drain (vkWaitSemaphores, INFINITE) on the render thread's critical path every frame. Over Juice's remote vkWaitSemaphores each is a synchronous network round-trip, and together they cap queue depth at one frame in flight, defeating frame queue-ahead.

stw_context.c (stw_make_current): switching away from a shared context did ST_FLUSH_FRONT | ST_FLUSH_WAIT to retire shared-resource work before another context touches it. Drop the WAIT and flush without blocking; zink's per-batch timeline semaphores already order cross-context resource access GPU-side.

stw_st.c (stw_st_flush): every end-of-frame flush without a winsys framebuffer was upgraded to ST_FLUSH_WAIT as the SwapBuffers throttle. That CPU drain is only needed for the software-present path (softpipe/llvmpipe gdi_sw_display), which reads pixels back on the CPU. Zink presents via kopper: the present submit waits on the render-complete semaphore GPU-side and runs async, so the drain is redundant. Skip it for zink and let vkAcquireNextImageKHR provide back-pressure, which enables queue-ahead bounded by swapchain depth.