### PR TITLE
Increase ZINK_MAX_BINDLESS_HANDLES and include mechanism to prevent c…

### DIFF
--- a/src/gallium/drivers/zink/zink_context.c
+++ b/src/gallium/drivers/zink/zink_context.c
@@ -2011,7 +2011,7 @@ zink_set_sampler_views(struct pipe_context *pctx,
  * img_handle_bindings[] (VRED export smash).
  */
 static bool
-juice_bindless_alloc_slot(struct util_idalloc *slots, unsigned *out_slot)
+zink_bindless_alloc_slot(struct util_idalloc *slots, unsigned *out_slot)
 {
    unsigned slot = util_idalloc_alloc(slots);
    if (slot >= ZINK_MAX_BINDLESS_HANDLES) {
@@ -2075,7 +2075,7 @@ zink_create_texture_handle(struct pipe_context *pctx, struct pipe_sampler_view *
       zink_surface_reference(zink_screen(pctx->screen), &bd->ds.surface, sv->image_view);
 
    unsigned slot;
-   if (!juice_bindless_alloc_slot(&ctx->di.bindless[bd->ds.is_buffer].tex_slots, &slot)) {
+   if (!zink_bindless_alloc_slot(&ctx->di.bindless[bd->ds.is_buffer].tex_slots, &slot)) {
       if (bd->ds.is_buffer)
          zink_buffer_view_reference(zink_screen(pctx->screen), &bd->ds.bufferview, NULL);
       else
@@ -2285,7 +2285,7 @@ zink_create_image_handle(struct pipe_context *pctx, const struct pipe_image_view
       bd->ds.surface = create_image_surface(ctx, view, false);
 
    unsigned slot;
-   if (!juice_bindless_alloc_slot(&ctx->di.bindless[bd->ds.is_buffer].img_slots, &slot)) {
+   if (!zink_bindless_alloc_slot(&ctx->di.bindless[bd->ds.is_buffer].img_slots, &slot)) {
       if (bd->ds.is_buffer)
          zink_buffer_view_reference(zink_screen(pctx->screen), &bd->ds.bufferview, NULL);
       else

--- a/src/gallium/drivers/zink/zink_context.c
+++ b/src/gallium/drivers/zink/zink_context.c
@@ -2005,6 +2005,25 @@ zink_set_sampler_views(struct pipe_context *pctx,
    }
 }
 
+/*
+ * util_idalloc_alloc grows past the initial size. Bindless CPU/GPU tables are
+ * fixed at ZINK_MAX_BINDLESS_HANDLES — refuse overflow so we never OOB-write
+ * img_handle_bindings[] (VRED export smash).
+ */
+static bool
+juice_bindless_alloc_slot(struct util_idalloc *slots, unsigned *out_slot)
+{
+   unsigned slot = util_idalloc_alloc(slots);
+   if (slot >= ZINK_MAX_BINDLESS_HANDLES) {
+      util_idalloc_free(slots, slot);
+      mesa_loge("ZINK BINDLESS: handle table full (max=%u); rejecting create",
+                ZINK_MAX_BINDLESS_HANDLES);
+      return false;
+   }
+   *out_slot = slot;
+   return true;
+}
+
 /* CIS tuple binding (dim, is_array, is_shadow) for a sampler-view bindless
  * handle; recorded at create time as the primary binding for its descriptor
  * write (which still fans out to every tuple binding, see update_bindless). */
@@ -2054,7 +2073,19 @@ zink_create_texture_handle(struct pipe_context *pctx, struct pipe_sampler_view *
       zink_buffer_view_reference(zink_screen(pctx->screen), &bd->ds.bufferview, sv->buffer_view);
    else
       zink_surface_reference(zink_screen(pctx->screen), &bd->ds.surface, sv->image_view);
-   uint64_t handle = util_idalloc_alloc(&ctx->di.bindless[bd->ds.is_buffer].tex_slots);
+
+   unsigned slot;
+   if (!juice_bindless_alloc_slot(&ctx->di.bindless[bd->ds.is_buffer].tex_slots, &slot)) {
+      if (bd->ds.is_buffer)
+         zink_buffer_view_reference(zink_screen(pctx->screen), &bd->ds.bufferview, NULL);
+      else
+         zink_surface_reference(zink_screen(pctx->screen), &bd->ds.surface, NULL);
+      pctx->delete_sampler_state(pctx, bd->sampler);
+      free(bd);
+      return 0;
+   }
+
+   uint64_t handle = slot;
    if (bd->ds.is_buffer)
       handle += ZINK_MAX_BINDLESS_HANDLES;
    bd->handle = handle;
@@ -2066,10 +2097,9 @@ zink_create_texture_handle(struct pipe_context *pctx, struct pipe_sampler_view *
     * looks up buf_handle_bindings on the same side, so both branches write
     * the bindless[0] arrays. */
    if (!bd->ds.is_buffer) {
-      ctx->di.bindless[0].img_handle_bindings[handle] =
+      ctx->di.bindless[0].img_handle_bindings[slot] =
          juice_tex_handle_tuple_binding(view, state);
    } else {
-      uint64_t slot = handle - ZINK_MAX_BINDLESS_HANDLES;
       ctx->di.bindless[0].buf_handle_bindings[slot] =
          ZINK_BINDLESS_UTEX_BINDING;
    }
@@ -2253,7 +2283,18 @@ zink_create_image_handle(struct pipe_context *pctx, const struct pipe_image_view
       bd->ds.bufferview = create_image_bufferview(ctx, view);
    else
       bd->ds.surface = create_image_surface(ctx, view, false);
-   uint64_t handle = util_idalloc_alloc(&ctx->di.bindless[bd->ds.is_buffer].img_slots);
+
+   unsigned slot;
+   if (!juice_bindless_alloc_slot(&ctx->di.bindless[bd->ds.is_buffer].img_slots, &slot)) {
+      if (bd->ds.is_buffer)
+         zink_buffer_view_reference(zink_screen(pctx->screen), &bd->ds.bufferview, NULL);
+      else
+         zink_surface_reference(zink_screen(pctx->screen), &bd->ds.surface, NULL);
+      free(bd);
+      return 0;
+   }
+
+   uint64_t handle = slot;
    if (bd->ds.is_buffer)
       handle += ZINK_MAX_BINDLESS_HANDLES;
    bd->handle = handle;
@@ -2264,10 +2305,9 @@ zink_create_image_handle(struct pipe_context *pctx, const struct pipe_image_view
     * zink_make_image_handle_resident), so both branches write the
     * bindless[1] arrays. */
    if (!bd->ds.is_buffer) {
-      ctx->di.bindless[1].img_handle_bindings[handle] =
+      ctx->di.bindless[1].img_handle_bindings[slot] =
          juice_img_handle_tuple_binding(view);
    } else {
-      uint64_t slot = handle - ZINK_MAX_BINDLESS_HANDLES;
       ctx->di.bindless[1].buf_handle_bindings[slot] =
          ZINK_BINDLESS_STEX_BINDING;
    }

--- a/src/gallium/drivers/zink/zink_types.h
+++ b/src/gallium/drivers/zink/zink_types.h
@@ -70,9 +70,12 @@
 #define MAX_LAZY_DESCRIPTORS 500
 /* explicit clamping because descriptor caching used to exist */
 #define ZINK_MAX_SHADER_IMAGES 32
-/* total bindless ids per side; raised from stock 1024 because VRED exceeds it
- * (24 sampler bindings * 8192 = 196608 UAB images, under the A6000's ~1M) */
-#define ZINK_MAX_BINDLESS_HANDLES 8192
+/* total bindless ids per side; raised again because VRED export AA exceeds
+ * 8192 (observed peak ~21k). Descriptor pool stays under ~1M UAB images
+ * (24 sampler bindings * 32768). util_idalloc can grow past this — create
+ * paths must reject slot >= ZINK_MAX_BINDLESS_HANDLES to avoid OOB writes
+ * into img_handle_bindings / related arrays. */
+#define ZINK_MAX_BINDLESS_HANDLES 32768
 
 /* enum zink_descriptor_type */
 #define ZINK_MAX_DESCRIPTOR_SETS 6


### PR DESCRIPTION
…raches because of exausting table